### PR TITLE
 Fix typos and grammatical errors in documentation

### DIFF
--- a/basic/block-explores.md
+++ b/basic/block-explores.md
@@ -2,7 +2,7 @@
 icon: browser
 ---
 
-# Block Explores
+# Block Explorers
 
 Blockchain explorers allow users to query the blockchain for data. Explorers are often compared to search engines for the blockchain. By using an explorer, users can search and track balances, transactions, contracts, and other broadcast data to the blockchain.
 

--- a/pvm/pvm.md
+++ b/pvm/pvm.md
@@ -15,7 +15,7 @@ PVM follows the FACADE design pattern, which makes the difference between blockc
 PVM provides Go/Java/JavaScript SDKs to manipulate different blockchains.
 <figure><img src="../.gitbook/assets/pvm-3.png" alt=""><figcaption></figcaption></figure>
 
-### Fee agregation
+### Fee aggregation
 Fee aggregation is a multi-chain fee solution to simplify the gas processing procedure and to lower on-chain costs. The technologies behind fee aggregation include fee pools, transaction aggregation, state indexer, cross-chain bridge, and oracle.
 
 ### PVM Protocol
@@ -23,13 +23,13 @@ PVM protocol is a set of universal, human-readable, well structured, extendable 
 PVM protocols are based on popular smart contract use cases, such as fungible assets and non-fungible assets. For a certain smart contract use case, the corresponding protocol covers all the operations. Take a fungible asset as an example. The protocol contains Create, Transfer, Approval, TransferFrom，TotalSupply, BalanceOf, Allowance.
 
 ### PVM Interpreter
-As we mentioned earlier, developers can initiate transactions that can be executed on various blockchains through the same protocol (PVM protocol). Because the tech details are different from one blockchain to another, we need a component to translate the same protocol into different on chain standards.
+As we mentioned earlier, developers can initiate transactions that can be executed on various blockchains through the same protocol (PVM protocol). Because the tech details are different from one blockchain to another, we need a component to translate the same protocol into different on-chain standards.
 So it is reasonable to design a translator component called PVM-Interpreter.
 <figure><img src="../.gitbook/assets/pvm-4.png" alt=""><figcaption></figcaption></figure>
 
 Workflow:
 1. Developer configs the dialect and chain info
 2. Developer builds a transaction (take transfer of fungible asset as an example), which follows the PVM Omni Protocol.
-3. The PVM interpreter will translate the transaction into ton executable on chain transaction.
+3. The PVM interpreter will translate the transaction into ton executable on-chain transaction.
 4. The user signs the transaction.
 5. Send the on-chain transaction to service node.

--- a/testnet-v2/testnet-v2.md
+++ b/testnet-v2/testnet-v2.md
@@ -1,6 +1,6 @@
 # Testnet V2
 
-We're gonna to launch the Testnet V2 in August after the Tabi Captain Node Pre-sale
+We're going to launch the Testnet V2 in August after the Tabi Captain Node Pre-sale
 On Testnet V2, we will gradually open dapps. Meanwhile, if you own a node, you can also participate in Test-mining to get test token, which allows you to experience all functions on Tabi Testnet V2
 
 ## Test-mining   


### PR DESCRIPTION
**basic/block-explores.md**
- Corrected the heading ("Block Explores" → "Block Explorers").

**pvm/pvm.md**
- "agregation" to "aggregation"

**testnet-v2/testnet-v2.md**
- Replaced "gonna" with "going" for a more formal tone.