### PR TITLE
Update block-explores.md

### DIFF
--- a/basic/block-explores.md
+++ b/basic/block-explores.md
@@ -14,4 +14,4 @@ Below is a list of public block explorers that support Tabichain Testnet:
 
 | Service       | Support | URL                                                   |
 | ------------- | ------- | ----------------------------------------------------- |
-| BlockExporter | `evm`   | [testnet.tabiscan.com](https://testnet.tabiscan.com/) |
+| Block Explorer | `evm`   | [testnet.tabiscan.com](https://testnet.tabiscan.com/) |


### PR DESCRIPTION
fix the minor typo at the [Block Explorer](https://tabichain.gitbook.io/tabichain/basic/block-explores) page.

![image](https://github.com/user-attachments/assets/caeaf54f-ccc2-4a75-99e5-ee41d668f26a)
